### PR TITLE
Update spectrogram.c

### DIFF
--- a/projects/sox-log-spectrogram/spectrogram.c
+++ b/projects/sox-log-spectrogram/spectrogram.c
@@ -148,6 +148,11 @@ static int parse_num_with_suffix (const char *s, int *a) {
  * b is left unchanged. If :<b> then 'a' will be set to 0.
  * Return 0 of successful, -1 on failure.
  */
+/**The strchr() function is preferred over this function.
+For maximum portability, it is recommended to replace the function call to index() as follows:
+Twobob 2016 ref: http://pubs.opengroup.org/onlinepubs/000095399/functions/index.html
+*/
+#define index(a,b) strchr((a),(b))
 static int parse_range (const char *s, int *a, int *b) {
   int a_status, b_status;
   char *colon = index(s,':');


### PR DESCRIPTION
as per http://pubs.opengroup.org/onlinepubs/000095399/functions/index.html this needs the define to build under windows. Confirmed as building okay with 14.4.2 as of today with this patch.
![testtoday](https://cloud.githubusercontent.com/assets/915232/17100525/d8905848-5266-11e6-82c3-7ae5b05b7fdd.png)
![testtoday-nolog](https://cloud.githubusercontent.com/assets/915232/17100538/e532ab6e-5266-11e6-8596-661800aa4140.png)
